### PR TITLE
Enable Unattended upgrades

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,10 @@ RUN echo "deb http://deb.ooni.org/ unstable main" | tee /etc/apt/sources.list.d/
 
 RUN apt-get update && apt-get install -y ooniprobe-cli
 
+RUN apt-get install -y unattended-upgrades apt-listchanges
+
+RUN sed -i '/Unattended-Upgrade::Origins-Pattern {/a "origin=ooni";' /etc/apt/apt.conf.d/50unattended-upgrades
+
 ARG USER=ooniprobe
 
 USER $USER


### PR DESCRIPTION
Which one of these two lines should I add? 

xRef: https://unix.stackexchange.com/questions/651918/unattended-upgradeorigins-pattern-for-repository-without-origin-label-etc
```
Unattended-Upgrade::Origins-Pattern {
     "origin=ooni";
 }
```
or
```
 Unattended-Upgrade::Origins-Pattern {
     "origin=ooni,n=unstable";
}
```

Check this
```
$ apt-cache policy
Package files:
 100 /var/lib/dpkg/status
     release a=now
 500 http://deb.ooni.org/ unstable/main arm64 Packages
     release o=ooni,n=unstable,c=main,b=arm64
     origin deb.ooni.org
 500 http://deb.debian.org/debian bullseye-updates/main arm64 Packages
     release v=11-updates,o=Debian,a=stable-updates,n=bullseye-updates,l=Debian,c=main,b=arm64
     origin deb.debian.org
 500 http://deb.debian.org/debian-security bullseye-security/main arm64 Packages
     release v=11,o=Debian,a=stable-security,n=bullseye-security,l=Debian-Security,c=main,b=arm64
     origin deb.debian.org
 500 http://deb.debian.org/debian bullseye/main arm64 Packages
     release v=11.6,o=Debian,a=stable,n=bullseye,l=Debian,c=main,b=arm64
     origin deb.debian.org
```
